### PR TITLE
Add Shodan-based endpoint discovery script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
-Basic script to converse with Ollama endpoints.  
-"endpoints.csv" needs to be populated with valid Ollama endpoints
+Basic script to converse with Ollama endpoints.
+"endpoints.csv" needs to be populated with valid Ollama endpoints.
+
+## Automatic population
+
+The `shodan_scan.py` helper uses the [Shodan](https://www.shodan.io/) API to
+keep `endpoints.csv` up to date. It performs two tasks:
+
+1. Verify the online status of servers already present in the CSV using a
+   single batched query per port.
+2. Search Shodan for additional public Ollama instances and append them.
+
+Set your API key in the environment and run the script:
+
+```bash
+export SHODAN_API_KEY=your_key_here
+python shodan_scan.py
+```
+
+The script requires the `shodan` and `pandas` packages.  It also enriches each
+entry with metadata provided by Shodan such as hostnames, organisation, ISP and
+geolocation (city, region, country and coordinates) so the CSV remains as
+informative as possible.

--- a/endpoints.csv
+++ b/endpoints.csv
@@ -1,3 +1,3 @@
-id,ip,port,scan_date,verified,verification_date,is_active,inactive_reason,last_check_date,api_type
-Ollama LLM server 1,1.1.1.1,11434,2025-04-20T20:38:52.125129+00:00,0,,FALSE,connection error,2025-04-20T20:38:52.125129+00:00,ollama
-Ollama LLM server 2,2.2.2.2,11434,2025-04-20T20:38:52.125129+00:00,1,,TRUE,,2025-04-20T20:38:52.125129+00:00,ollama
+id,ip,port,scan_date,verified,verification_date,is_active,inactive_reason,last_check_date,api_type,hostnames,org,isp,city,region,country,latitude,longitude
+Ollama LLM server 1,1.1.1.1,11434,2025-04-20T20:38:52.125129+00:00,0,,FALSE,connection error,2025-04-20T20:38:52.125129+00:00,ollama,,,,ExampleCity,ExampleRegion,ExampleCountry,0,0
+Ollama LLM server 2,2.2.2.2,11434,2025-04-20T20:38:52.125129+00:00,1,2025-04-20T20:38:52.125129+00:00,TRUE,,2025-04-20T20:38:52.125129+00:00,ollama,,,,ExampleCity,ExampleRegion,ExampleCountry,0,0

--- a/shodan_scan.py
+++ b/shodan_scan.py
@@ -1,0 +1,151 @@
+import os
+from datetime import datetime, timezone
+
+import pandas as pd
+import shodan
+
+CSV_PATH = "endpoints.csv"
+SHODAN_QUERIES = [
+    'port:11434 "Ollama"'
+]
+
+COLUMNS = [
+    "id",
+    "ip",
+    "port",
+    "scan_date",
+    "verified",
+    "verification_date",
+    "is_active",
+    "inactive_reason",
+    "last_check_date",
+    "api_type",
+    "hostnames",
+    "org",
+    "isp",
+    "city",
+    "region",
+    "country",
+    "latitude",
+    "longitude",
+]
+
+
+def utc_now():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def update_existing(api, df):
+    if df.empty:
+        return df
+
+    # Batch the IPs by port to minimise API requests.
+    grouped = {}
+    for _, row in df.iterrows():
+        port = int(row["port"])
+        grouped.setdefault(port, set()).add(row["ip"])
+
+    details = {}
+    errors = {}
+    for port, ips in grouped.items():
+        ip_query = " OR ".join(f"ip:{ip}" for ip in ips)
+        query = f"port:{port} ({ip_query})"
+        try:
+            results = api.search(query, limit=len(ips)).get("matches", [])
+            for r in results:
+                key = (r.get("ip_str"), r.get("port"))
+                details[key] = r
+        except shodan.APIError as e:
+            for ip in ips:
+                errors[(ip, port)] = str(e)
+
+    now = utc_now()
+    for idx, row in df.iterrows():
+        ip = row["ip"]
+        port = int(row["port"])
+        key = (ip, port)
+        r = details.get(key)
+        if r:
+            location = r.get("location", {})
+            df.at[idx, "is_active"] = True
+            df.at[idx, "inactive_reason"] = ""
+            df.at[idx, "last_check_date"] = now
+            df.at[idx, "scan_date"] = r.get("timestamp", row.get("scan_date", now))
+            df.at[idx, "verified"] = 1
+            df.at[idx, "verification_date"] = now
+            df.at[idx, "hostnames"] = ";".join(r.get("hostnames", []))
+            df.at[idx, "org"] = r.get("org", "")
+            df.at[idx, "isp"] = r.get("isp", "")
+            df.at[idx, "city"] = location.get("city", "")
+            df.at[idx, "region"] = location.get("region_code") or location.get("region_name", "")
+            df.at[idx, "country"] = location.get("country_name", "")
+            df.at[idx, "latitude"] = location.get("latitude", "")
+            df.at[idx, "longitude"] = location.get("longitude", "")
+        else:
+            df.at[idx, "is_active"] = False
+            df.at[idx, "inactive_reason"] = errors.get(key, "port closed")
+            df.at[idx, "last_check_date"] = now
+    return df
+
+
+def find_new(api, df):
+    existing = set(zip(df["ip"], df["port"]))
+    new_rows = []
+    for query in SHODAN_QUERIES:
+        try:
+            results = api.search(query).get("matches", [])
+        except shodan.APIError:
+            continue
+        for r in results:
+            ip = r.get("ip_str")
+            port = r.get("port")
+            if (ip, str(port)) in existing:
+                continue
+            location = r.get("location", {})
+            scan_date = r.get("timestamp", utc_now())
+            new_rows.append({
+                "id": f"Shodan {ip}:{port}",
+                "ip": ip,
+                "port": port,
+                "scan_date": scan_date,
+                "verified": 0,
+                "verification_date": "",
+                "is_active": True,
+                "inactive_reason": "",
+                "last_check_date": scan_date,
+                "api_type": "ollama",
+                "hostnames": ";".join(r.get("hostnames", [])),
+                "org": r.get("org", ""),
+                "isp": r.get("isp", ""),
+                "city": location.get("city", ""),
+                "region": location.get("region_code") or location.get("region_name", ""),
+                "country": location.get("country_name", ""),
+                "latitude": location.get("latitude", ""),
+                "longitude": location.get("longitude", ""),
+            })
+            existing.add((ip, str(port)))
+    if new_rows:
+        df = pd.concat([df, pd.DataFrame(new_rows)], ignore_index=True)
+    return df
+
+
+def main():
+    key = os.getenv("SHODAN_API_KEY")
+    if not key:
+        raise RuntimeError("SHODAN_API_KEY environment variable not set")
+    api = shodan.Shodan(key)
+    try:
+        df = pd.read_csv(CSV_PATH, keep_default_na=False)
+    except FileNotFoundError:
+        df = pd.DataFrame(columns=COLUMNS)
+    for col in COLUMNS:
+        if col not in df.columns:
+            df[col] = ""
+    df = update_existing(api, df)
+    df = find_new(api, df)
+    df = df[COLUMNS]
+    df.to_csv(CSV_PATH, index=False)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document automatic population of endpoints in README
- add `shodan_scan.py` to verify existing servers, discover new ones, and enrich CSV rows with hostnames, provider, and location data
- batch Shodan queries to verify existing servers with minimal API hits

## Testing
- `python -m py_compile TerminalAI.py shodan_scan.py`


------
https://chatgpt.com/codex/tasks/task_e_68a39b94f9988332ac1e3d24114ba95c