### PR TITLE
Load Shodan API key from config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+config.json
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -10,10 +10,19 @@ keep `endpoints.csv` up to date. It performs two tasks:
    single batched query per port.
 2. Search Shodan for additional public Ollama instances and append them.
 
-Set your API key in the environment and run the script:
+Create a `config.json` next to `shodan_scan.py` with your API key. A
+`config.example.json` template is provided:
+
+```json
+{
+  "SHODAN_API_KEY": "your_key_here"
+}
+```
+
+Alternatively, set the `SHODAN_API_KEY` environment variable. The file takes
+precedence over the environment variable if both are present. Run the script:
 
 ```bash
-export SHODAN_API_KEY=your_key_here
 python shodan_scan.py
 ```
 

--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,3 @@
+{
+  "SHODAN_API_KEY": "your_shodan_api_key"
+}


### PR DESCRIPTION
## Summary
- add example `config.json` template and ignore the real config file
- read the Shodan API key from a local config file with environment fallback
- document configuration file usage and precedence in README

## Testing
- `python -m py_compile shodan_scan.py TerminalAI.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3a451a7f083328abaa8b30187578d