### PR TITLE
Allow configuring batch size for Shodan endpoint verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Basic script to converse with Ollama endpoints.
 The `shodan_scan.py` helper uses the [Shodan](https://www.shodan.io/) API to
 keep `endpoints.csv` up to date. It performs two tasks:
 
-1. Verify the online status of servers already present in the CSV using a
-   single batched query per port.
+1. Verify the online status of servers already present in the CSV using
+   batched queries per port.
 2. Search Shodan for additional public Ollama instances and append them.
 
 Create a `config.json` next to `shodan_scan.py` with your API key. A
@@ -35,13 +35,15 @@ python shodan_scan.py --verbose
 ```
 
 To control API usage, results from each Shodan query are limited to 100 entries by default.
-Use `--limit` to change this value:
+Use `--limit` to change how many new endpoints are fetched per query.
+Existing entries are checked in batches of 100; adjust this with `--existing-limit` to
+control API usage for large CSVs.
 
 ```bash
-python shodan_scan.py --limit 50
+python shodan_scan.py --limit 50 --existing-limit 25
 ```
 
-The script requires the `shodan` and `pandas` packages.  It also enriches each
+The script requires the `shodan` and `pandas` packages. It also enriches each
 entry with metadata provided by Shodan such as hostnames, organisation, ISP and
 geolocation (city, region, country and coordinates) so the CSV remains as
 informative as possible.


### PR DESCRIPTION
## Summary
- add `batch_size` parameter to `update_existing` and chunk large IP lists
- expose `--existing-limit` flag to configure batch size for existing endpoints
- document new flag and usage in README

## Testing
- `python -m py_compile shodan_scan.py`
- `python -m py_compile TerminalAI.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3b1e02b088332b334d5819dd074db