### PR TITLE
Refine Shodan query for Ollama servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ keep `endpoints.csv` up to date. It performs two tasks:
    batched queries per port.
 2. Search Shodan for additional public Ollama instances and append them.
 
+By default the script looks for hosts on the standard Ollama port (11434)
+whose HTTP response contains the text "Ollama is running".
+
 Create a `config.json` next to `shodan_scan.py` with your API key. A
 `config.example.json` template is provided:
 

--- a/shodan_scan.py
+++ b/shodan_scan.py
@@ -11,7 +11,7 @@ import shodan
 CSV_PATH = "endpoints.csv"
 CONFIG_PATH = Path(__file__).with_name("config.json")
 SHODAN_QUERIES = [
-    'port:11434 "Ollama"'
+    'http.html:"Ollama is running" port:11434'
 ]
 
 COLUMNS = [


### PR DESCRIPTION
## Summary
- target Shodan search to port 11434 hosts whose HTTP body contains "Ollama is running"
- document default query for finding Ollama servers

## Testing
- `python -m py_compile shodan_scan.py`
- `python shodan_scan.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68a3bfd0582c833294caba07ec78be23