### PR TITLE
Use emoji flags and clean Shodan IDs

### DIFF
--- a/TerminalAI.py
+++ b/TerminalAI.py
@@ -38,11 +38,15 @@ def api_headers():
 def country_flag(name):
     if not name:
         return ""
-    try:
-        code = pycountry.countries.lookup(name).alpha_2
-    except Exception:
+    code = name.strip().upper()
+    if len(code) != 2:
+        try:
+            code = pycountry.countries.lookup(code).alpha_2.upper()
+        except Exception:
+            return ""
+    if len(code) != 2 or not code.isalpha():
         return ""
-    return "".join(chr(ord(c) + 127397) for c in code.upper())
+    return "".join(chr(ord(c) + 127397) for c in code)
 
 def load_servers():
     try:

--- a/shodan_scan.py
+++ b/shodan_scan.py
@@ -43,13 +43,13 @@ def utc_now():
 def build_name(ip, port, city, org):
     org = org or ""
     org = (org[:17] + "...") if len(org) > 20 else org
-    parts = ["Shodan"]
+    parts = []
     if city:
         parts.append(city)
     if org:
         parts.append(org)
     parts.append(f"({ip}:{port})")
-    return " ".join(parts)
+    return " ".join(parts).strip()
 
 
 def load_api_key():


### PR DESCRIPTION
## Summary
- Normalize country names and use proper Unicode regional indicator symbols for emoji flags
- Stop prefixing endpoint IDs with "Shodan" when scanning

## Testing
- `python -m py_compile TerminalAI.py shodan_scan.py`


------
https://chatgpt.com/codex/tasks/task_e_68a42305433c8332a6f5203087f74357