### PR TITLE
Streamline server IDs and remove flag display

### DIFF
--- a/TerminalAI.py
+++ b/TerminalAI.py
@@ -7,7 +7,6 @@ import sys
 import shutil
 import pandas as pd
 import select
-import pycountry
 
 if os.name == "nt":
     import msvcrt
@@ -35,18 +34,6 @@ def api_headers():
     return {"Content-Type": "application/json"}
 
 
-def country_flag(name):
-    if not name:
-        return ""
-    code = name.strip().upper()
-    if len(code) != 2:
-        try:
-            code = pycountry.countries.lookup(code).alpha_2.upper()
-        except Exception:
-            return ""
-    if len(code) != 2 or not code.isalpha():
-        return ""
-    return "".join(chr(ord(c) + 127397) for c in code)
 
 def load_servers():
     try:
@@ -84,8 +71,7 @@ def persist_nickname(server, new_nick):
 def select_server(servers):
     print(f"{CYAN}Available Servers:{RESET}")
     for i, s in enumerate(servers, 1):
-        flag = country_flag(s.get("country"))
-        print(f"{GREEN}{i}. {flag} {s['nickname']} ({s['ip']}){RESET}")
+        print(f"{GREEN}{i}. {s['nickname']} ({s['ip']}){RESET}")
     while True:
         c = input(f"{CYAN}Select server: {RESET}").strip()
         if c.isdigit() and 1 <= int(c) <= len(servers):
@@ -126,9 +112,8 @@ def redraw_ui(model):
     os.system("cls" if os.name == "nt" else "clear")
     ip = selected_server['ip']
     port = selected_server['apis'][selected_api]
-    flag = country_flag(selected_server.get("country"))
     print(f"{BOLD}{GREEN}AI Terminal Interface 🖥️ | {ip}:{port}{RESET}")
-    print(f"{GREEN}Active Model: {model} | {flag} {selected_server['nickname']}{RESET}")
+    print(f"{GREEN}Active Model: {model} | {selected_server['nickname']}{RESET}")
     print(f"{YELLOW}Type prompts below. Commands: /exit, /clear, /paste, /back, /print, /nick{RESET}")
 
 def display_connecting_box():

--- a/shodan_scan.py
+++ b/shodan_scan.py
@@ -40,16 +40,13 @@ def utc_now():
     return datetime.now(timezone.utc).isoformat()
 
 
-def build_name(ip, port, city, org):
+def build_name(city, country, org):
     org = org or ""
     org = (org[:17] + "...") if len(org) > 20 else org
-    parts = []
-    if city:
-        parts.append(city)
-    if org:
-        parts.append(org)
-    parts.append(f"({ip}:{port})")
-    return " ".join(parts).strip()
+    location = ", ".join([p for p in [city, country] if p])
+    if org and location:
+        return f"{location} ({org})"
+    return location or org
 
 
 def load_api_key():
@@ -119,10 +116,11 @@ def update_existing(api, df, batch_size):
             city = location.get("city", "")
             df.at[idx, "city"] = city
             df.at[idx, "region"] = location.get("region_code") or location.get("region_name", "")
-            df.at[idx, "country"] = location.get("country_name", "")
+            country = location.get("country_name", "")
+            df.at[idx, "country"] = country
             df.at[idx, "latitude"] = location.get("latitude", "")
             df.at[idx, "longitude"] = location.get("longitude", "")
-            df.at[idx, "id"] = build_name(ip, port, city, org)
+            df.at[idx, "id"] = build_name(city, country, org)
         else:
             df.at[idx, "is_active"] = False
             df.at[idx, "inactive_reason"] = errors.get(key, "port closed")
@@ -150,8 +148,9 @@ def find_new(api, df, limit):
             scan_date = r.get("timestamp", utc_now())
             org = r.get("org", "")
             city = location.get("city", "")
+            country = location.get("country_name", "")
             new_rows.append({
-                "id": build_name(ip, port, city, org),
+                "id": build_name(city, country, org),
                 "ip": ip,
                 "port": port,
                 "scan_date": scan_date,
@@ -166,7 +165,7 @@ def find_new(api, df, limit):
                 "isp": r.get("isp", ""),
                 "city": city,
                 "region": location.get("region_code") or location.get("region_name", ""),
-                "country": location.get("country_name", ""),
+                "country": country,
                 "latitude": location.get("latitude", ""),
                 "longitude": location.get("longitude", ""),
             })


### PR DESCRIPTION
## Summary
- Drop country flag column and flag usage for broader terminal compatibility
- Build server IDs from `city, country` and organization without embedding IP

## Testing
- `python -m py_compile TerminalAI.py shodan_scan.py`


------
https://chatgpt.com/codex/tasks/task_e_68a578f64f408332829a5b46799d3883