### PR TITLE
Keep matrix rain active during ping check, avoid pandas warning, sanitize conversation filenames, and sort server list by ping

### DIFF
--- a/shodan_scan.py
+++ b/shodan_scan.py
@@ -208,7 +208,10 @@ def find_new(api, df, limit):
                 new_df.at[idx, "ping"] = latency
                 new_df.at[idx, "is_active"] = True
                 new_df.at[idx, "inactive_reason"] = ""
-        df = pd.concat([df, new_df], ignore_index=True)
+        if df.empty:
+            df = new_df
+        else:
+            df = pd.concat([df, new_df], ignore_index=True)
     return df
 
 


### PR DESCRIPTION
## Summary
- Keep matrix rain animation running until ping thread completes by running it in its own thread with a stop event.
- Prevent pandas `FutureWarning` by skipping concatenation when the existing DataFrame is empty.
- Sanitize model names when saving conversations to avoid invalid file paths on Windows.
- Order available servers by ping latency so the lowest ping appears first.

## Testing
- `python3 -m py_compile TerminalAI.py shodan_scan.py`


------
https://chatgpt.com/codex/tasks/task_e_68a69b86210c83328ab2e8e95eae8d32