### PR TITLE
feat: sync launchers and refine shodan scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ the `logs` directory, which is created automatically if needed.
 
 ## Automatic population
 
-The `shodan_scan.py` helper uses the [Shodan](https://www.shodan.io/) API to
+The `shodanscan.py` helper uses the [Shodan](https://www.shodan.io/) API to
 keep `endpoints.csv` up to date. It performs two tasks:
 
 1. Verify the online status of servers already present in the CSV using
@@ -35,7 +35,7 @@ As part of the scan each server is also pinged locally. The round-trip time is
 stored in the `ping` column and any host that does not answer is marked
 inactive.
 
-Create a `config.json` next to `shodan_scan.py` with your API key. A
+Create a `config.json` next to `shodanscan.py` with your API key. A
 `config.example.json` template is provided:
 
 ```json
@@ -48,7 +48,7 @@ Alternatively, set the `SHODAN_API_KEY` environment variable. The file takes
 precedence over the environment variable if both are present. Run the script:
 
 ```bash
-python shodan_scan.py
+python shodanscan.py
 ```
 
 The script uses Python's built-in logging module to report its progress. By
@@ -56,16 +56,16 @@ default it logs informational messages; pass `--verbose` to enable debug level
 output:
 
 ```bash
-python shodan_scan.py --verbose
+python shodanscan.py --verbose
 ```
 
-To control API usage, results from each Shodan query are limited to 100 entries by default.
-Use `--limit` to change how many new endpoints are fetched per query.
-Existing entries are checked in batches of 100; adjust this with `--existing-limit` to
-control API usage for large CSVs.
+By default results from each Shodan query are limited to 25 new endpoints.
+Use `--limit` to change how many fresh results are appended per query.
+Existing entries are checked starting with the oldest `last_check_date`; adjust
+`--existing-limit` to control how many are verified on each run.
 
 ```bash
-python shodan_scan.py --limit 50 --existing-limit 25
+python shodanscan.py --limit 50 --existing-limit 25
 ```
 
 The script requires the `shodan` and `pandas` packages. It also enriches each

--- a/launcher.bat
+++ b/launcher.bat
@@ -2,7 +2,7 @@
 chcp 65001 > nul
 for /F "delims=" %%a in ('echo prompt $E ^| cmd') do set "ESC=%%a"
 
-echo %ESC%[95m
+echo %ESC%[32m
 echo ███████╗███████╗██████╗ ███╗   ███╗██╗███╗   ██╗ █████╗ ██╗     
 echo ╚══██╔══╝██╔════╝██╔══██╗████╗ ████║██║████╗  ██║██╔══██╗██║     
 echo    ██║   █████╗  ██████╔╝██╔████╔██║██║██╔██╗ ██║███████║██║     
@@ -11,14 +11,19 @@ echo    ██║   ███████╗██║  ██║██║ ╚═
 echo    ╚═╝   ╚══════╝╚═╝  ╚═╝╚═╝     ╚═╝╚═╝╚═╝  ╚═══╝╚═╝  ╚═╝╚══════╝
 echo %ESC%[0m
 echo.
-echo 1^) Scan Shodan
-echo 2^) Use TerminalAI
-set /p choice=Select option: 
+echo %ESC%[32m┌────────────────────────────────┐
+echo │ 1) Start TerminalAI           │
+echo │ 2) Scan Shodan                │
+echo └────────────────────────────────┘%ESC%[0m
+start "Rain" /B python rain.py --header-top 0 --header-bottom 5 --box-top 8 --box-bottom 11 --box-left 23 --box-right 56 --prompt-row 12
+set /p choice=Select option:
+
+taskkill /FI "WINDOWTITLE eq Rain" > nul
 
 if "%choice%"=="1" (
-    python shodan_scan.py %*
-) else if "%choice%"=="2" (
     python TerminalAI.py %*
+) else if "%choice%"=="2" (
+    python shodanscan.py %*
 ) else (
     echo Invalid selection
     exit /b 1

--- a/launcher.sh
+++ b/launcher.sh
@@ -1,23 +1,89 @@
 #!/usr/bin/env bash
 set -e
 
-printf '\033[95m'
-cat <<'ART'
-████████╗███████╗██████╗ ███╗   ███╗██╗███╗   ██╗ █████╗ ██╗     
-╚══██╔══╝██╔════╝██╔══██╗████╗ ████║██║████╗  ██║██╔══██╗██║     
-   ██║   █████╗  ██████╔╝██╔████╔██║██║██╔██╗ ██║███████║██║     
-   ██║   ██╔══╝  ██╔══██╗██║╚██╔╝██║██║██║╚██╗██║██╔══██║██║     
-   ██║   ███████╗██║  ██║██║ ╚═╝ ██║██║██║ ╚████║██║  ██║███████╗
-   ╚═╝   ╚══════╝╚═╝  ╚═╝╚═╝     ╚═╝╚═╝╚═╝  ╚═══╝╚═╝  ╚═╝╚══════╝
-ART
-printf '\033[0m\n'
+GREEN="\033[32m"
+RESET="\033[0m"
+BOLD="\033[1m"
 
-echo "1) Scan Shodan"
-echo "2) Use TerminalAI"
+clear
+tput civis
+
+ROWS=$(tput lines)
+COLS=$(tput cols)
+
+HEADER_HEIGHT=6
+HEADER_TOP=0
+HEADER_BOTTOM=$((HEADER_TOP + HEADER_HEIGHT - 1))
+
+BOX_WIDTH=34
+BOX_HEIGHT=4
+BOX_TOP=$((HEADER_BOTTOM + 2))
+BOX_LEFT=$(((COLS - BOX_WIDTH) / 2))
+BOX_RIGHT=$((BOX_LEFT + BOX_WIDTH - 1))
+BOX_BOTTOM=$((BOX_TOP + BOX_HEIGHT - 1))
+PROMPT_ROW=$((BOX_BOTTOM + 1))
+
+draw_header() {
+  local start_col=$(((COLS - 68) / 2))
+  tput cup $HEADER_TOP $start_col
+  printf "${BOLD}${GREEN}████████╗███████╗██████╗ ███╗   ███╗██╗███╗   ██╗ █████╗ ██╗\n"
+  tput cup $((HEADER_TOP+1)) $start_col
+  printf "╚══██╔══╝██╔════╝██╔══██╗████╗ ████║██║████╗  ██║██╔══██╗██║\n"
+  tput cup $((HEADER_TOP+2)) $start_col
+  printf "   ██║   █████╗  ██████╔╝██╔████╔██║██║██╔██╗ ██║███████║██║\n"
+  tput cup $((HEADER_TOP+3)) $start_col
+  printf "   ██║   ██╔══╝  ██╔══██╗██║╚██╔╝██║██║██║╚██╗██║██╔══██║██║\n"
+  tput cup $((HEADER_TOP+4)) $start_col
+  printf "   ██║   ███████╗██║  ██║██║ ╚═╝ ██║██║██║ ╚████║██║  ██║███████╗\n"
+  tput cup $((HEADER_TOP+5)) $start_col
+  printf "   ╚═╝   ╚══════╝╚═╝  ╚═╝╚═╝     ╚═╝╚═╝╚═╝  ╚═══╝╚═╝  ╚═╝╚══════╝${RESET}"
+}
+
+draw_box() {
+  tput cup $BOX_TOP $BOX_LEFT
+  printf "${GREEN}┌"
+  printf '─%.0s' $(seq 1 $((BOX_WIDTH-2)))
+  printf "┐"
+  for ((i=1; i<=BOX_HEIGHT-2; i++)); do
+    tput cup $((BOX_TOP+i)) $BOX_LEFT
+    printf "│"
+    tput cup $((BOX_TOP+i)) $((BOX_LEFT+BOX_WIDTH-1))
+    printf "│"
+  done
+  tput cup $BOX_BOTTOM $BOX_LEFT
+  printf "└"
+  printf '─%.0s' $(seq 1 $((BOX_WIDTH-2)))
+  printf "┘${RESET}"
+}
+
+print_options() {
+  tput cup $((BOX_TOP+1)) $((BOX_LEFT+2))
+  printf "${GREEN}1) Start TerminalAI"
+  tput cup $((BOX_TOP+2)) $((BOX_LEFT+2))
+  printf "2) Scan Shodan${RESET}"
+}
+
+draw_header
+draw_box
+print_options
+
+python rain.py --header-top "$HEADER_TOP" --header-bottom "$HEADER_BOTTOM" \
+  --box-top "$BOX_TOP" --box-bottom "$BOX_BOTTOM" --box-left "$BOX_LEFT" \
+  --box-right "$BOX_RIGHT" --prompt-row "$PROMPT_ROW" &
+R_PID=$!
+
+cleanup() {
+  kill $R_PID 2>/dev/null || true
+  tput cnorm
+  clear
+}
+trap cleanup EXIT
+
+tput cup $PROMPT_ROW $BOX_LEFT
 read -p "Select option: " choice
 
 case "$choice" in
-  1) python shodan_scan.py "$@" ;;
-  2) python TerminalAI.py "$@" ;;
-  *) echo "Invalid selection" >&2; exit 1 ;;
+  1) cleanup; python TerminalAI.py "$@" ;;
+  2) cleanup; python shodanscan.py "$@" ;;
+  *) cleanup; echo "Invalid selection" >&2; exit 1 ;;
 esac

--- a/rain.py
+++ b/rain.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+import argparse
+import random
+import shutil
+import sys
+import time
+
+GREEN = "\033[32m"
+RESET = "\033[0m"
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--header-top", type=int, default=0)
+    parser.add_argument("--header-bottom", type=int, default=-1)
+    parser.add_argument("--box-top", type=int, default=0)
+    parser.add_argument("--box-bottom", type=int, default=-1)
+    parser.add_argument("--box-left", type=int, default=0)
+    parser.add_argument("--box-right", type=int, default=-1)
+    parser.add_argument("--prompt-row", type=int, default=0)
+    args = parser.parse_args()
+
+    cols, rows = shutil.get_terminal_size()
+    chars = "01"
+    try:
+        while True:
+            r = random.randint(0, max(args.prompt_row - 1, 0))
+            c = random.randint(0, cols - 1)
+            if args.header_top <= r <= args.header_bottom:
+                continue
+            if (
+                args.box_top <= r <= args.box_bottom
+                and args.box_left <= c <= args.box_right
+            ):
+                continue
+            sys.stdout.write(f"\033[{r};{c}H{GREEN}{random.choice(chars)}{RESET}")
+            sys.stdout.flush()
+            time.sleep(0.05)
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- present unified launcher menus with shared rain animation
- default Shodan scan to 25 new results and verify oldest endpoints first
- document new `shodanscan.py` usage and limits
- start rain animation during "HACK THE PLANET" intro and drop matrix naming

## Testing
- `python -m py_compile TerminalAI.py shodanscan.py rain.py`
- `bash -n launcher.sh`
- `timeout 1 ./launcher.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a6c45e670c8332ab8a9c61ac99222b