### PR TITLE
Fix back navigation and rain overlay issues

### DIFF
--- a/TerminalAI.py
+++ b/TerminalAI.py
@@ -683,7 +683,7 @@ if __name__ == "__main__":
     ping_thread.join()
     stop_rain.set()
     rain_thread.join()
-    display_connecting_box(box_x, box_y, box_w, box_h)
+    os.system("cls" if os.name == "nt" else "clear")
 
     while True:
         # 1. Load and pick a server
@@ -716,13 +716,21 @@ if __name__ == "__main__":
 
             # 4. Pick or start conversation
             while True:
-                conv_file, messages, history, context = select_conversation(chosen)
-                if conv_file == 'back':
-                    break  # back to model selection
+                if has_conversations(chosen):
+                    conv_file, messages, history, context = select_conversation(chosen)
+                    if conv_file == 'back':
+                        break  # back to model selection
+                else:
+                    print(f"{CYAN}No previous conversations found.{RESET}")
+                    conv_file, messages, history, context = (None, [], [], None)
 
                 result = chat_loop(chosen, conv_file, messages, history, context)
                 if result == 'back':
-                    continue  # back to conversation selection
+                    if has_conversations(chosen):
+                        continue  # back to conversation selection
+                    else:
+                        conv_file = 'back'
+                        break
                 elif result == 'server_inactive':
                     conv_file = 'server_inactive'
                     break

--- a/launcher.sh
+++ b/launcher.sh
@@ -65,14 +65,14 @@ print_options() {
   printf "2) Scan Shodan${RESET}"
 }
 
-draw_header
-draw_box
-print_options
-
 python3 rain.py --persistent \
   --exclude "$HEADER_TOP,$HEADER_BOTTOM,$HEADER_LEFT,$HEADER_RIGHT" \
   --exclude "$BOX_TOP,$BOX_BOTTOM,$BOX_LEFT,$BOX_RIGHT" &
 R_PID=$!
+
+draw_header
+draw_box
+print_options
 
 cleanup() {
   kill $R_PID 2>/dev/null || true


### PR DESCRIPTION
## Summary
- prevent launcher's rain effect from clearing menu by starting rain before drawing header and options
- clear screen after initial rain in TerminalAI and allow `/back` to return to model list when no conversations exist

## Testing
- `python -m py_compile TerminalAI.py rain.py shodanscan.py`
- `bash -n launcher.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a6eaa822bc8332851d2ff85b645825