### PR TITLE
fix: align batch launcher display

### DIFF
--- a/launcher.bat
+++ b/launcher.bat
@@ -17,48 +17,59 @@ set /a ROWS=%ROWS: =%
 
 set /a HEADER_HEIGHT=6
 set /a HEADER_WIDTH=76
-set /a HEADER_TOP=1
-set /a HEADER_LEFT=(COLS-HEADER_WIDTH)/2+1
+set /a HEADER_TOP=0
+set /a HEADER_LEFT=(COLS-HEADER_WIDTH)/2
 set /a HEADER_BOTTOM=HEADER_TOP+HEADER_HEIGHT-1
 set /a HEADER_RIGHT=HEADER_LEFT+HEADER_WIDTH-1
 
 set /a BOX_WIDTH=34
 set /a BOX_HEIGHT=4
 set /a BOX_TOP=HEADER_BOTTOM+2
-set /a BOX_LEFT=(COLS-BOX_WIDTH)/2+1
+set /a BOX_LEFT=(COLS-BOX_WIDTH)/2
 set /a BOX_BOTTOM=BOX_TOP+BOX_HEIGHT-1
 set /a BOX_RIGHT=BOX_LEFT+BOX_WIDTH-1
 
+set /a RAIN_HEADER_TOP=HEADER_TOP+1
+set /a RAIN_HEADER_BOTTOM=HEADER_BOTTOM+1
+set /a RAIN_HEADER_LEFT=HEADER_LEFT+1
+set /a RAIN_HEADER_RIGHT=HEADER_RIGHT+1
+set /a RAIN_BOX_TOP=BOX_TOP+1
+set /a RAIN_BOX_BOTTOM=BOX_BOTTOM+1
+set /a RAIN_BOX_LEFT=BOX_LEFT+1
+set /a RAIN_BOX_RIGHT=BOX_RIGHT+1
+
 start "Rain" /B %PYTHON% "%SCRIPT_DIR%scripts\rain.py" --persistent --no-clear ^
-  --exclude !HEADER_TOP!,!HEADER_BOTTOM!,!HEADER_LEFT!,!HEADER_RIGHT! ^
-  --exclude !BOX_TOP!,!BOX_BOTTOM!,!BOX_LEFT!,!BOX_RIGHT!
+  --exclude !RAIN_HEADER_TOP!,!RAIN_HEADER_BOTTOM!,!RAIN_HEADER_LEFT!,!RAIN_HEADER_RIGHT! ^
+  --exclude !RAIN_BOX_TOP!,!RAIN_BOX_BOTTOM!,!RAIN_BOX_LEFT!,!RAIN_BOX_RIGHT!
 
-set /a ROW=HEADER_TOP
-echo %ESC%[!ROW!;!HEADER_LEFT!H%ESC%[32;1m████████╗███████╗██████╗ ███╗   ███╗██╗███╗   ██╗ █████╗ ██╗      █████╗ ██╗
+set /a ROW=HEADER_TOP+1
+set /a COL=HEADER_LEFT+1
+echo %ESC%[!ROW!;!COL!H%ESC%[32;1m████████╗███████╗██████╗ ███╗   ███╗██╗███╗   ██╗ █████╗ ██╗      █████╗ ██╗
 set /a ROW+=1
-echo %ESC%[!ROW!;!HEADER_LEFT!H╚══██╔══╝██╔════╝██╔══██╗████╗ ████║██║████╗  ██║██╔══██╗██║     ██╔══██╗██║
+echo %ESC%[!ROW!;!COL!H╚══██╔══╝██╔════╝██╔══██╗████╗ ████║██║████╗  ██║██╔══██╗██║     ██╔══██╗██║
 set /a ROW+=1
-echo %ESC%[!ROW!;!HEADER_LEFT!H   ██║   █████╗  ██████╔╝██╔████╔██║██║██╔██╗ ██║███████║██║     ███████║██║
+echo %ESC%[!ROW!;!COL!H   ██║   █████╗  ██████╔╝██╔████╔██║██║██╔██╗ ██║███████║██║     ███████║██║
 set /a ROW+=1
-echo %ESC%[!ROW!;!HEADER_LEFT!H   ██║   ██╔══╝  ██╔══██╗██║╚██╔╝██║██║██║╚██╗██║██╔══██║██║     ██╔══██║██║
+echo %ESC%[!ROW!;!COL!H   ██║   ██╔══╝  ██╔══██╗██║╚██╔╝██║██║██║╚██╗██║██╔══██║██║     ██╔══██║██║
 set /a ROW+=1
-echo %ESC%[!ROW!;!HEADER_LEFT!H   ██║   ███████╗██║  ██║██║ ╚═╝ ██║██║██║ ╚████║██║  ██║███████╗██║  ██║██║
+echo %ESC%[!ROW!;!COL!H   ██║   ███████╗██║  ██║██║ ╚═╝ ██║██║██║ ╚████║██║  ██║███████╗██║  ██║██║
 set /a ROW+=1
-echo %ESC%[!ROW!;!HEADER_LEFT!H   ╚═╝   ╚══════╝╚═╝  ╚═╝╚═╝     ╚═╝╚═╝╚═╝  ╚═══╝╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚═╝%ESC%[0m
+echo %ESC%[!ROW!;!COL!H   ╚═╝   ╚══════╝╚═╝  ╚═╝╚═╝     ╚═╝╚═╝╚═╝  ╚═══╝╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚═╝%ESC%[0m
 
-set /a ROW=BOX_TOP
+set /a ROW=BOX_TOP+1
+set /a COL=BOX_LEFT+1
 set "HORZ="
 for /L %%i in (1,1,!BOX_WIDTH!-2) do set "HORZ=!HORZ!─"
-echo %ESC%[!ROW!;!BOX_LEFT!H%ESC%[32m┌!HORZ!┐
+echo %ESC%[!ROW!;!COL!H%ESC%[32m┌!HORZ!┐
 for /L %%i in (1,1,!BOX_HEIGHT!-2) do (
-  set /a ROW=BOX_TOP+%%i
-  echo %ESC%[!ROW!;!BOX_LEFT!H│%ESC%[!ROW!;!BOX_RIGHT!H│
+  set /a ROW=BOX_TOP+1+%%i
+  echo %ESC%[!ROW!;!COL!H│%ESC%[!ROW!;!BOX_RIGHT+1!H│
 )
-set /a ROW=BOX_BOTTOM
-echo %ESC%[!ROW!;!BOX_LEFT!H└!HORZ!┘%ESC%[0m
+set /a ROW=BOX_BOTTOM+1
+echo %ESC%[!ROW!;!COL!H└!HORZ!┘%ESC%[0m
 
-set /a OPTION_COL=BOX_LEFT+2
-set /a ROW=BOX_TOP+1
+set /a OPTION_COL=BOX_LEFT+3
+set /a ROW=BOX_TOP+2
 echo %ESC%[!ROW!;!OPTION_COL!H%ESC%[32m1) Start TerminalAI
 set /a ROW+=1
 echo %ESC%[!ROW!;!OPTION_COL!H2) Scan Shodan%ESC%[0m


### PR DESCRIPTION
## Summary
- align batch launcher with shell version by using 0-based coordinates and converting for rain exclusions
- draw header and option box using 1-based coordinates to match terminal layout

## Testing
- `python -m py_compile scripts/rain.py`

------
https://chatgpt.com/codex/tasks/task_e_68a7e3211e8083329b6559c67155ae27