### PR TITLE
fix: align batch launcher display

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ TerminalAI is a retro-styled client for chatting with Ollama models and for disc
 2. **Install Python dependencies**
 
    ```bash
-   pip install -r requirements.txt
+   pip3 install -r requirements.txt
    ```
 
 3. **Prepare data files**
@@ -42,7 +42,7 @@ Press `1` or `2` to choose an action. The launcher restores the console on exit.
 Run the chat client directly if desired:
 
 ```bash
-python scripts/TerminalAI.py
+python3 scripts/TerminalAI.py
 ```
 
 The client loads servers from `data/endpoints.csv`, pings them to sort by latency, and stores conversations under `data/conversations`. Logs produced with the `/print` command are written to `data/logs`.
@@ -52,7 +52,7 @@ The client loads servers from `data/endpoints.csv`, pings them to sort by latenc
 Scan for new Ollama servers and verify existing ones:
 
 ```bash
-python scripts/shodanscan.py [--verbose] [--limit N] [--existing-limit N]
+python3 scripts/shodanscan.py [--verbose] [--limit N] [--existing-limit N]
 ```
 
 The script requires a Shodan API key. Results are appended to `data/endpoints.csv` and enriched with metadata such as hostnames, organisation, ISP, and location. Existing entries are checked for availability and ping time.
@@ -62,7 +62,7 @@ The script requires a Shodan API key. Results are appended to `data/endpoints.cs
 Run a basic syntax check on all Python scripts:
 
 ```bash
-python -m py_compile scripts/*.py
+python3 -m py_compile scripts/*.py
 ```
 
 ## Data Layout

--- a/launcher.bat
+++ b/launcher.bat
@@ -4,64 +4,80 @@ for /F "delims=" %%a in ('echo prompt $E ^| cmd') do set "ESC=%%a"
 setlocal EnableDelayedExpansion
 
 set "SCRIPT_DIR=%~dp0"
-set "PYTHON=python"
-where python3 > nul 2>&1 && set "PYTHON=python3"
+set "PYTHON=python3"
+
+set "GREEN=%ESC%[32m"
+set "RESET=%ESC%[0m"
+set "BOLD=%ESC%[1m"
 
 cls
 echo %ESC%[?25l
 
-for /F "tokens=2 delims=:" %%a in ('mode con ^| findstr /R "Columns"') do set "COLS=%%a"
-for /F "tokens=2 delims=:" %%a in ('mode con ^| findstr /R "Lines"') do set "ROWS=%%a"
-set /a COLS=%COLS: =%
-set /a ROWS=%ROWS: =%
+for /F "tokens=2 delims=:" %%a in ('mode con ^| findstr /R "Columns"') do (
+  for %%b in (%%a) do set "COLS=%%b"
+)
+for /F "tokens=2 delims=:" %%a in ('mode con ^| findstr /R "Lines"') do (
+  for %%b in (%%a) do set "ROWS=%%b"
+)
 
 set /a HEADER_HEIGHT=6
 set /a HEADER_WIDTH=76
-set /a HEADER_TOP=1
-set /a HEADER_LEFT=(COLS-HEADER_WIDTH)/2+1
+set /a HEADER_TOP=0
+set /a HEADER_LEFT=(COLS-HEADER_WIDTH)/2
 set /a HEADER_BOTTOM=HEADER_TOP+HEADER_HEIGHT-1
 set /a HEADER_RIGHT=HEADER_LEFT+HEADER_WIDTH-1
 
 set /a BOX_WIDTH=34
 set /a BOX_HEIGHT=4
 set /a BOX_TOP=HEADER_BOTTOM+2
-set /a BOX_LEFT=(COLS-BOX_WIDTH)/2+1
+set /a BOX_LEFT=(COLS-BOX_WIDTH)/2
 set /a BOX_BOTTOM=BOX_TOP+BOX_HEIGHT-1
 set /a BOX_RIGHT=BOX_LEFT+BOX_WIDTH-1
 
-start "Rain" /B %PYTHON% "%SCRIPT_DIR%scripts\rain.py" --persistent --no-clear ^
-  --exclude !HEADER_TOP!,!HEADER_BOTTOM!,!HEADER_LEFT!,!HEADER_RIGHT! ^
-  --exclude !BOX_TOP!,!BOX_BOTTOM!,!BOX_LEFT!,!BOX_RIGHT!
+set /a RAIN_HEADER_TOP=HEADER_TOP+1
+set /a RAIN_HEADER_BOTTOM=HEADER_BOTTOM+1
+set /a RAIN_HEADER_LEFT=HEADER_LEFT+1
+set /a RAIN_HEADER_RIGHT=HEADER_RIGHT+1
+set /a RAIN_BOX_TOP=BOX_TOP+1
+set /a RAIN_BOX_BOTTOM=BOX_BOTTOM+1
+set /a RAIN_BOX_LEFT=BOX_LEFT+1
+set /a RAIN_BOX_RIGHT=BOX_RIGHT+1
 
-set /a ROW=HEADER_TOP
-echo %ESC%[!ROW!;!HEADER_LEFT!H%ESC%[32;1m████████╗███████╗██████╗ ███╗   ███╗██╗███╗   ██╗ █████╗ ██╗      █████╗ ██╗
+set /a ROW=HEADER_TOP+1
+set /a COL=HEADER_LEFT+1
+echo %ESC%[!ROW!;!COL!H!BOLD!!GREEN!████████╗███████╗██████╗ ███╗   ███╗██╗███╗   ██╗ █████╗ ██╗      █████╗ ██╗
 set /a ROW+=1
-echo %ESC%[!ROW!;!HEADER_LEFT!H╚══██╔══╝██╔════╝██╔══██╗████╗ ████║██║████╗  ██║██╔══██╗██║     ██╔══██╗██║
+echo %ESC%[!ROW!;!COL!H╚══██╔══╝██╔════╝██╔══██╗████╗ ████║██║████╗  ██║██╔══██╗██║     ██╔══██╗██║
 set /a ROW+=1
-echo %ESC%[!ROW!;!HEADER_LEFT!H   ██║   █████╗  ██████╔╝██╔████╔██║██║██╔██╗ ██║███████║██║     ███████║██║
+echo %ESC%[!ROW!;!COL!H   ██║   █████╗  ██████╔╝██╔████╔██║██║██╔██╗ ██║███████║██║     ███████║██║
 set /a ROW+=1
-echo %ESC%[!ROW!;!HEADER_LEFT!H   ██║   ██╔══╝  ██╔══██╗██║╚██╔╝██║██║██║╚██╗██║██╔══██║██║     ██╔══██║██║
+echo %ESC%[!ROW!;!COL!H   ██║   ██╔══╝  ██╔══██╗██║╚██╔╝██║██║██║╚██╗██║██╔══██║██║     ██╔══██║██║
 set /a ROW+=1
-echo %ESC%[!ROW!;!HEADER_LEFT!H   ██║   ███████╗██║  ██║██║ ╚═╝ ██║██║██║ ╚████║██║  ██║███████╗██║  ██║██║
+echo %ESC%[!ROW!;!COL!H   ██║   ███████╗██║  ██║██║ ╚═╝ ██║██║██║ ╚████║██║  ██║███████╗██║  ██║██║
 set /a ROW+=1
-echo %ESC%[!ROW!;!HEADER_LEFT!H   ╚═╝   ╚══════╝╚═╝  ╚═╝╚═╝     ╚═╝╚═╝╚═╝  ╚═══╝╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚═╝%ESC%[0m
+echo %ESC%[!ROW!;!COL!H   ╚═╝   ╚══════╝╚═╝  ╚═╝╚═╝     ╚═╝╚═╝╚═╝  ╚═══╝╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚═╝!RESET!
 
-set /a ROW=BOX_TOP
+set /a ROW=BOX_TOP+1
+set /a COL=BOX_LEFT+1
 set "HORZ="
 for /L %%i in (1,1,!BOX_WIDTH!-2) do set "HORZ=!HORZ!─"
-echo %ESC%[!ROW!;!BOX_LEFT!H%ESC%[32m┌!HORZ!┐
+echo %ESC%[!ROW!;!COL!H!GREEN!┌!HORZ!┐
 for /L %%i in (1,1,!BOX_HEIGHT!-2) do (
-  set /a ROW=BOX_TOP+%%i
-  echo %ESC%[!ROW!;!BOX_LEFT!H│%ESC%[!ROW!;!BOX_RIGHT!H│
+  set /a ROW=BOX_TOP+1+%%i
+  echo %ESC%[!ROW!;!COL!H│%ESC%[!ROW!;!BOX_RIGHT+1!H│
 )
-set /a ROW=BOX_BOTTOM
-echo %ESC%[!ROW!;!BOX_LEFT!H└!HORZ!┘%ESC%[0m
+set /a ROW=BOX_BOTTOM+1
+echo %ESC%[!ROW!;!COL!H└!HORZ!┘!RESET!
 
-set /a OPTION_COL=BOX_LEFT+2
-set /a ROW=BOX_TOP+1
-echo %ESC%[!ROW!;!OPTION_COL!H%ESC%[32m1) Start TerminalAI
+set /a OPTION_COL=BOX_LEFT+3
+set /a ROW=BOX_TOP+2
+echo %ESC%[!ROW!;!OPTION_COL!H!GREEN!1) Start TerminalAI
 set /a ROW+=1
-echo %ESC%[!ROW!;!OPTION_COL!H2) Scan Shodan%ESC%[0m
+echo %ESC%[!ROW!;!OPTION_COL!H2) Scan Shodan!RESET!
+
+start "Rain" /B %PYTHON% "%SCRIPT_DIR%scripts\rain.py" --persistent --no-clear ^
+  --exclude !RAIN_HEADER_TOP!,!RAIN_HEADER_BOTTOM!,!RAIN_HEADER_LEFT!,!RAIN_HEADER_RIGHT! ^
+  --exclude !RAIN_BOX_TOP!,!RAIN_BOX_BOTTOM!,!RAIN_BOX_LEFT!,!RAIN_BOX_RIGHT!
 
 choice /c 12 /n >nul
 set "CHOICE=%errorlevel%"


### PR DESCRIPTION
## Summary
- ensure Windows launcher mirrors shell layout with consistent green header, centered box, and rain excluded
- rely exclusively on `python3` across batch script and documentation

## Testing
- `python3 -m py_compile scripts/rain.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7e3211e8083329b6559c67155ae27