### PR TITLE
Enable arrow key navigation for input editing

### DIFF
--- a/scripts/launcher.py
+++ b/scripts/launcher.py
@@ -138,15 +138,21 @@ def get_key():
             if ch == "\x1b":
                 seq = ""
                 while True:
-                    dr, _, _ = select.select([sys.stdin], [], [], 0.05)
+                    dr, _, _ = select.select([sys.stdin], [], [], 0.2)
                     if dr:
                         seq += sys.stdin.read(1)
+                        if seq[-1] in "ABCD":
+                            break
                     else:
                         break
                 if seq.endswith("A"):
                     return "UP"
                 if seq.endswith("B"):
                     return "DOWN"
+                if seq.endswith("C"):
+                    return "RIGHT"
+                if seq.endswith("D"):
+                    return "LEFT"
                 return "ESC"
             if ch in ("\n", "\r"):
                 return "ENTER"


### PR DESCRIPTION
## Summary
- allow arrow-key navigation while typing by reworking `get_input`
- maintain cross-platform ESC detection
- make arrow key detection in launcher and terminal menus more robust

## Testing
- `python -m py_compile scripts/TerminalAI.py scripts/launcher.py`


------
https://chatgpt.com/codex/tasks/task_e_68a80fb871348332bf71791e7eabe8a4