### PR TITLE
Align menus left and color green

### DIFF
--- a/scripts/TerminalAI.py
+++ b/scripts/TerminalAI.py
@@ -22,7 +22,7 @@ else:
     import tty
 
 # ANSI colors
-GREEN = "\033[92m"
+GREEN = "\033[38;2;5;249;0m"
 CYAN = "\033[96m"
 YELLOW = "\033[93m"
 RED = "\033[91m"
@@ -229,15 +229,17 @@ def interactive_menu(header, options):
     offset = 0
     while True:
         clear_screen()
-        print(f"{CYAN}{header}{RESET}")
+        print(f"{GREEN}{header}{RESET}")
         rows = shutil.get_terminal_size(fallback=(80, 24)).lines
         view_height = max(1, rows - 2)
         end = offset + view_height
         visible = options[offset:end]
         for i, opt in enumerate(visible):
             actual = offset + i
-            marker = f"{YELLOW}> {RESET}" if actual == idx else "  "
-            line = f"{BOLD}{opt}{RESET}" if actual == idx else opt
+            marker = f"{GREEN}> {RESET}" if actual == idx else "  "
+            line = (
+                f"{BOLD}{GREEN}{opt}{RESET}" if actual == idx else f"{GREEN}{opt}{RESET}"
+            )
             print(f"{marker}{line}")
         key = get_key()
         if key == "UP":
@@ -417,10 +419,7 @@ def select_server(servers):
         for i, s in enumerate(servers, 1):
             ping_val = s.get("ping", float("inf"))
             ping_str = "?" if ping_val == float("inf") else f"{ping_val:.1f} ms"
-            color = heat_color(ping_val)
-            ip_col = f"{color}{s['ip']}{RESET}"
-            ping_col = f"{color}{ping_str}{RESET}"
-            print(f"{GREEN}{i}. {s['nickname']}{RESET} ({ip_col}) - {ping_col}")
+            print(f"{GREEN}{i}. {s['nickname']} ({s['ip']}) - {ping_str}{RESET}")
         while True:
             c = get_input(f"{CYAN}Select server: {RESET}")
             if c == "ESC":
@@ -437,10 +436,7 @@ def select_server(servers):
         for s in servers:
             ping_val = s.get("ping", float("inf"))
             ping_str = "?" if ping_val == float("inf") else f"{ping_val:.1f} ms"
-            color = heat_color(ping_val)
-            ip_col = f"{color}{s['ip']}{RESET}"
-            ping_col = f"{color}{ping_str}{RESET}"
-            options.append(f"{s['nickname']} ({ip_col}) - {ping_col}")
+            options.append(f"{s['nickname']} ({s['ip']}) - {ping_str}")
         while True:
             choice = interactive_menu("Available Servers:", options)
             if choice is None:

--- a/scripts/curses_nav.py
+++ b/scripts/curses_nav.py
@@ -1,24 +1,48 @@
 import curses
 import curses.textpad
 
+
 def get_input(prompt: str) -> str:
     """Prompt for input with basic line editing using curses."""
+
     def _inner(stdscr):
         curses.curs_set(1)
         curses.echo()
-        stdscr.addstr(prompt)
+        curses.start_color()
+        try:
+            if curses.can_change_color():
+                curses.init_color(10, 20, 976, 0)
+                curses.init_pair(1, 10, curses.COLOR_BLACK)
+            else:
+                curses.init_pair(1, curses.COLOR_GREEN, curses.COLOR_BLACK)
+        except curses.error:
+            curses.init_pair(1, curses.COLOR_GREEN, curses.COLOR_BLACK)
+        green = curses.color_pair(1)
+        stdscr.addstr(prompt, green)
         stdscr.refresh()
         win = curses.newwin(1, curses.COLS - len(prompt) - 1, 0, len(prompt))
         box = curses.textpad.Textbox(win)
         text = box.edit().strip()
         return text
+
     return curses.wrapper(_inner)
 
 
-def interactive_menu(header: str, options: list[str]) -> int | None:
+def interactive_menu(header: str, options: list[str], *, center: bool = False) -> int | None:
     """Simple vertical menu navigated with arrow keys."""
+
     def _menu(stdscr):
         curses.curs_set(0)
+        curses.start_color()
+        try:
+            if curses.can_change_color():
+                curses.init_color(10, 20, 976, 0)
+                curses.init_pair(1, 10, curses.COLOR_BLACK)
+            else:
+                curses.init_pair(1, curses.COLOR_GREEN, curses.COLOR_BLACK)
+        except curses.error:
+            curses.init_pair(1, curses.COLOR_GREEN, curses.COLOR_BLACK)
+        green = curses.color_pair(1)
         idx = 0
         offset = 0
         header_lines = header.split("\n") if header else []
@@ -26,18 +50,18 @@ def interactive_menu(header: str, options: list[str]) -> int | None:
         while True:
             stdscr.erase()
             rows, cols = stdscr.getmaxyx()
-            # draw header centered
+            # draw header
             for i, line in enumerate(header_lines):
-                x = max((cols - len(line)) // 2, 0)
-                stdscr.addstr(i, x, line)
+                x = max((cols - len(line)) // 2, 0) if center else 0
+                stdscr.addstr(i, x, line, green)
             view_height = max(1, rows - header_height - 1)
-            visible = options[offset:offset + view_height]
+            visible = options[offset : offset + view_height]
             for i, opt in enumerate(visible):
                 actual = offset + i
                 marker = "> " if actual == idx else "  "
                 text = marker + opt
-                x = max((cols - len(text)) // 2, 0)
-                attr = curses.A_BOLD if actual == idx else curses.A_NORMAL
+                x = max((cols - len(text)) // 2, 0) if center else 0
+                attr = green | (curses.A_BOLD if actual == idx else curses.A_NORMAL)
                 stdscr.addstr(header_height + i, x, text, attr)
             key = stdscr.getch()
             if key == curses.KEY_UP:
@@ -52,4 +76,5 @@ def interactive_menu(header: str, options: list[str]) -> int | None:
                 offset = idx
             elif idx >= offset + view_height:
                 offset = idx - view_height + 1
+
     return curses.wrapper(_menu)

--- a/scripts/launcher.py
+++ b/scripts/launcher.py
@@ -6,6 +6,9 @@ import sys
 import shutil
 import threading
 
+GREEN = "\033[38;2;5;249;0m"
+RESET = "\033[0m"
+
 HEADER_LINES = [
     "████████╗███████╗██████╗ ███╗   ███╗██╗███╗   ██╗ █████╗ ██╗      █████╗ ██╗",
     "╚══██╔══╝██╔════╝██╔══██╗████╗ ████║██║████╗  ██║██╔══██╗██║     ██╔══██╗██║",
@@ -28,11 +31,11 @@ else:
 def run_verbose() -> int | None:
     """Display options and read numeric choice."""
     for line in HEADER_LINES:
-        print(line)
+        print(f"{GREEN}{line}{RESET}")
     for i, opt in enumerate(OPTIONS, 1):
-        print(f"{i}) {opt}")
+        print(f"{GREEN}{i}) {opt}{RESET}")
     try:
-        choice = input("> ").strip()
+        choice = input(f"{GREEN}> {RESET}").strip()
     except EOFError:
         return None
     return int(choice) - 1 if choice in {"1", "2"} else None
@@ -41,13 +44,15 @@ def run_verbose() -> int | None:
 def run_windows_menu() -> int | None:
     """Interactive menu using msvcrt for Windows."""
     idx = 0
+    columns, _ = shutil.get_terminal_size(fallback=(80, 24))
     while True:
         os.system("cls")
         for line in HEADER_LINES:
-            print(line)
+            print(f"{GREEN}{line.center(columns)}{RESET}")
         for i, opt in enumerate(OPTIONS):
             prefix = "> " if i == idx else "  "
-            print(prefix + opt)
+            text = prefix + opt
+            print(f"{GREEN}{text.center(columns)}{RESET}")
         ch = msvcrt.getwch()
         if ch in ("\r", "\n"):
             return idx
@@ -83,7 +88,7 @@ def run_unix_menu() -> int | None:
     )
     rain_thread.start()
     try:
-        return interactive_menu(header, OPTIONS)
+        return interactive_menu(header, OPTIONS, center=True)
     finally:
         stop_event.set()
         rain_thread.join()

--- a/scripts/rain.py
+++ b/scripts/rain.py
@@ -8,6 +8,7 @@ import sys
 import time
 
 RESET = "\033[0m"
+GREEN = "\033[38;2;5;249;0m"
 
 if os.name == "nt":
     import msvcrt
@@ -75,7 +76,7 @@ def rain(
                             continue
                         char = random.choice(charset) if t < 4 else " "
                         shade = (
-                            "\033[92m"
+                            GREEN
                             if t == 0
                             else "\033[32m"
                             if t == 1


### PR DESCRIPTION
## Summary
- make curses menus left-aligned by default with optional centering
- color all menu text green and remove stray ANSI codes from server listings
- center the launcher menu across platforms
- unify ANSI green across launcher, curses navigation, rain effect, and TerminalAI

## Testing
- `python -m py_compile scripts/curses_nav.py scripts/TerminalAI.py scripts/launcher.py scripts/rain.py`


------
https://chatgpt.com/codex/tasks/task_e_68a827a1f97c8332ac7d6cddbb9dcc22