### PR TITLE
Align chat output and box launcher UI

### DIFF
--- a/scripts/TerminalAI.py
+++ b/scripts/TerminalAI.py
@@ -536,7 +536,10 @@ def render_markdown(text):
             in_code = not in_code
             print("=" * 60)
             continue
-        print(ln.replace("</s>", ""))
+        out = ln.replace("</s>", "")
+        if not in_code:
+            out = out.lstrip()
+        print(out)
     print()
 
 def reprint_history(history):


### PR DESCRIPTION
## Summary
- Left-justify chat responses in TerminalAI for clearer reading
- Wrap launcher logo and menu in separate boxes with rain effect in between

## Testing
- `python -m py_compile scripts/TerminalAI.py scripts/launcher.py`

------
https://chatgpt.com/codex/tasks/task_e_68a82bade12483329bd25e7b933e1e9f