### PR TITLE
Enable rain effect for Windows launcher and clear Shodan scan output

### DIFF
--- a/scripts/TerminalAI.py
+++ b/scripts/TerminalAI.py
@@ -68,7 +68,7 @@ def start_thinking_timer():
         while not stop_event.is_set():
             elapsed = int(time.time() - start)
             print(
-                f"\r{AI_COLOR}\U0001f5a5️ : Thinking... ({elapsed}s){RESET}",
+                f"\r\033[K{AI_COLOR}\U0001f5a5️ : Thinking... ({elapsed}s){RESET}",
                 end="",
                 flush=True,
             )
@@ -83,7 +83,7 @@ def stop_thinking_timer(start, stop_event, timed_out=False):
     elapsed = int(time.time() - start)
     status = " [Timed out]" if timed_out else ""
     print(
-        f"\r{AI_COLOR}\U0001f5a5️ : Thinking... ({elapsed}s){status}{RESET}"
+        f"\r\033[K{AI_COLOR}\U0001f5a5️ : Thinking... ({elapsed}s){status}{RESET}"
     )
     return elapsed
 


### PR DESCRIPTION
## Summary
- add Matrix-style rain background to Windows launcher menu
- clear terminal before starting Shodan scan
- fix thinking timer line clearing to avoid spacing issues on Linux

## Testing
- `python -m py_compile scripts/*.py`
- `python scripts/launcher.py --verbose <<'EOF'
1
EOF` *(fails: No active servers available)*

------
https://chatgpt.com/codex/tasks/task_e_68a93090a79483329f5af4ed204fcc66