### PR TITLE
Fix Windows rain animation freeze in launcher

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/launcher.sh
+++ b/launcher.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
 set -e
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Resolve directory of this script, trimming any Windows carriage returns
+SCRIPT_PATH="${BASH_SOURCE[0]%$'\r'}"
+SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+SCRIPT_DIR="${SCRIPT_DIR%$'\r'}"
+
 python3 "$SCRIPT_DIR/scripts/launcher.py" "$@"

--- a/scripts/launcher.py
+++ b/scripts/launcher.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import shutil
 import threading
+import time
 
 GREEN = "\033[38;2;5;249;0m"
 RESET = "\033[0m"
@@ -72,34 +73,42 @@ def run_windows_menu() -> int | None:
     rain_thread.start()
 
     idx = 0
+
+    def draw_menu() -> None:
+        os.system("cls")
+        print(f"{' ' * header_x}{GREEN}┌{'─' * (header_w - 2)}┐{RESET}")
+        for line in HEADER_LINES:
+            print(f"{' ' * header_x}{GREEN}│{line.center(header_w - 2)}│{RESET}")
+        print(f"{' ' * header_x}{GREEN}└{'─' * (header_w - 2)}┘{RESET}")
+
+        for _ in range(max(0, menu_y - header_h)):
+            print()
+        print(f"{' ' * menu_x}{GREEN}┌{'─' * (menu_w - 2)}┐{RESET}")
+        for i, opt in enumerate(OPTIONS):
+            prefix = "> " if i == idx else "  "
+            line = prefix + opt
+            print(f"{' ' * menu_x}{GREEN}│{line.ljust(menu_w - 2)}│{RESET}")
+        print(f"{' ' * menu_x}{GREEN}└{'─' * (menu_w - 2)}┘{RESET}")
+
     try:
+        draw_menu()
         while True:
-            os.system("cls")
-            print(f"{' ' * header_x}{GREEN}┌{'─' * (header_w - 2)}┐{RESET}")
-            for line in HEADER_LINES:
-                print(f"{' ' * header_x}{GREEN}│{line.center(header_w - 2)}│{RESET}")
-            print(f"{' ' * header_x}{GREEN}└{'─' * (header_w - 2)}┘{RESET}")
-
-            for _ in range(max(0, menu_y - header_h)):
-                print()
-            print(f"{' ' * menu_x}{GREEN}┌{'─' * (menu_w - 2)}┐{RESET}")
-            for i, opt in enumerate(OPTIONS):
-                prefix = "> " if i == idx else "  "
-                line = prefix + opt
-                print(f"{' ' * menu_x}{GREEN}│{line.ljust(menu_w - 2)}│{RESET}")
-            print(f"{' ' * menu_x}{GREEN}└{'─' * (menu_w - 2)}┘{RESET}")
-
-            ch = msvcrt.getwch()
-            if ch in ("\r", "\n"):
-                return idx
-            if ch == "\x1b":
-                return None
-            if ch in ("\x00", "\xe0"):
-                ch2 = msvcrt.getwch()
-                if ch2 == "H":
-                    idx = (idx - 1) % len(OPTIONS)
-                elif ch2 == "P":
-                    idx = (idx + 1) % len(OPTIONS)
+            if msvcrt.kbhit():
+                ch = msvcrt.getwch()
+                if ch in ("\r", "\n"):
+                    return idx
+                if ch == "\x1b":
+                    return None
+                if ch in ("\x00", "\xe0"):
+                    ch2 = msvcrt.getwch()
+                    if ch2 == "H":
+                        idx = (idx - 1) % len(OPTIONS)
+                        draw_menu()
+                    elif ch2 == "P":
+                        idx = (idx + 1) % len(OPTIONS)
+                        draw_menu()
+            else:
+                time.sleep(0.05)
     finally:
         stop_event.set()
         rain_thread.join()

--- a/scripts/rain.py
+++ b/scripts/rain.py
@@ -95,7 +95,7 @@ def rain(
             time.sleep(0.08)
             if stop_event is not None and stop_event.is_set():
                 break
-            if persistent and (stop_event is None or not stop_event.is_set()):
+            if persistent and stop_event is None:
                 if os.name == "nt":
                     if msvcrt.kbhit():
                         msvcrt.getch()


### PR DESCRIPTION
## Summary
- keep rain animation running during menu navigation on Windows
- ignore keypresses when a stop event controls the rain thread
- trim Windows carriage returns from Linux launcher and enforce LF line endings for shell scripts

## Testing
- `python3 -m py_compile scripts/*.py`
- `bash -n launcher.sh`
- `shellcheck launcher.sh` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a93a5f727883329556bb584d414552