### PR TITLE
Use alternate screen for screensaver to prevent chat repetition

### DIFF
--- a/scripts/TerminalAI.py
+++ b/scripts/TerminalAI.py
@@ -609,11 +609,7 @@ def chat_loop(model, conv_file, messages=None, history=None, context=None):
                 while True:
                     if time.time() - start > IDLE_TIMEOUT:
                         if not VERBOSE:
-                            rain(persistent=True)
-                            redraw_ui(model)
-                            reprint_history(history)
-                            sys.stdout.write(f"{RESET}\U0001f9d1 : {user_input}")
-                            sys.stdout.flush()
+                            rain(persistent=True, use_alt_screen=True)
                         start = time.time()
                     if msvcrt.kbhit():
                         ch = msvcrt.getwch()
@@ -646,11 +642,7 @@ def chat_loop(model, conv_file, messages=None, history=None, context=None):
                     while True:
                         if time.time() - start > IDLE_TIMEOUT:
                             if not VERBOSE:
-                                rain(persistent=True)
-                                redraw_ui(model)
-                                reprint_history(history)
-                                sys.stdout.write(f"{RESET}\U0001f9d1 : {user_input}")
-                                sys.stdout.flush()
+                                rain(persistent=True, use_alt_screen=True)
                                 tty.setcbreak(fd)
                             start = time.time()
                         rlist, _, _ = select.select([sys.stdin], [], [], 0.1)

--- a/scripts/rain.py
+++ b/scripts/rain.py
@@ -27,6 +27,7 @@ def rain(
     box_right=None,
     boxes=None,
     clear_screen=True,
+    use_alt_screen=False,
 ):
     if boxes is None:
         boxes = []
@@ -46,9 +47,12 @@ def rain(
     old_settings = None
     stdin_is_tty = sys.stdin.isatty()
     try:
-        print("\033[?25l", end="")
-        if clear_screen:
-            os.system("cls" if os.name == "nt" else "clear")
+        if use_alt_screen:
+            print("\033[?1049h\033[?25l", end="")
+        else:
+            print("\033[?25l", end="")
+            if clear_screen:
+                os.system("cls" if os.name == "nt" else "clear")
         end_time = time.time() + duration if not persistent else None
         columns, rows = shutil.get_terminal_size(fallback=(80, 24))
         trail_length = 6
@@ -109,7 +113,9 @@ def rain(
         if os.name != "nt" and old_settings is not None and fd is not None:
             termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
         time.sleep(0.5)
-        if clear_screen:
+        if use_alt_screen:
+            print("\033[?25h\033[?1049l", end="")
+        elif clear_screen:
             print("\033[0m\033[2J\033[H\033[?25h", end="")
         else:
             print("\033[0m\033[?25h", end="")


### PR DESCRIPTION
## Summary
- add optional `use_alt_screen` mode to `rain` screensaver
- preserve chat display by invoking screensaver in an alternate buffer

## Testing
- `python -m py_compile scripts/TerminalAI.py scripts/rain.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac19ee54a88332a1a0a3405bf036da