### PR TITLE
Fix extra newline after thinking line and screensaver dismissal delay

### DIFF
--- a/scripts/TerminalAI.py
+++ b/scripts/TerminalAI.py
@@ -554,9 +554,6 @@ def reprint_history(history):
             print(f"{AI_COLOR}🖥️ : Thinking... ({wait}s){RESET}")
         else:
             print(f"{AI_COLOR}🖥️ : {RESET}")
-        # Leave a blank line before the AI's actual reply so history
-        # mirrors the live chat output.
-        print()
         render_markdown(e['ai'])
 
 def select_conversation(model):
@@ -692,11 +689,11 @@ def chat_loop(model, conv_file, messages=None, history=None, context=None):
                             elapsed = h.get("elapsed")
                             if elapsed is None:
                                 f.write(
-                                    f"User: {h['user']}\nAI:\n\n{h['ai']}\n\n"
+                                    f"User: {h['user']}\nAI:\n{h['ai']}\n\n"
                                 )
                             else:
                                 f.write(
-                                    f"User: {h['user']}\nAI: Thinking... ({elapsed}s)\n\n{h['ai']}\n\n"
+                                    f"User: {h['user']}\nAI: Thinking... ({elapsed}s)\n{h['ai']}\n\n"
                                 )
                     print(f"{YELLOW}Saved to {fn}{RESET}")
                 else:
@@ -830,14 +827,6 @@ def chat_loop(model, conv_file, messages=None, history=None, context=None):
                 server_failed = True
 
             elapsed = stop_thinking_timer(start, stop_event, timed_out)
-            # Provide a clean break between the thinking status line
-            # and the model's response. The previous implementation
-            # printed a secondary "Finished thinking" message and then
-            # redrew the AI prefix, which caused confusing output in
-            # both the live conversation and when reloading logs. We
-            # just add a blank line here so the response starts on its
-            # own line.
-            print()
 
             if server_failed:
                 try:
@@ -874,11 +863,11 @@ def chat_loop(model, conv_file, messages=None, history=None, context=None):
                         elapsed = h.get("elapsed")
                         if elapsed is None:
                             f.write(
-                                f"User: {h['user']}\nAI:\n\n{h['ai']}\n\n"
+                                f"User: {h['user']}\nAI:\n{h['ai']}\n\n"
                             )
                         else:
                             f.write(
-                                f"User: {h['user']}\nAI: Thinking... ({elapsed}s)\n\n{h['ai']}\n\n"
+                                f"User: {h['user']}\nAI: Thinking... ({elapsed}s)\n{h['ai']}\n\n"
                             )
                 print(f"Saved to {fn}")
 

--- a/scripts/rain.py
+++ b/scripts/rain.py
@@ -48,9 +48,9 @@ def rain(
     stdin_is_tty = sys.stdin.isatty()
     try:
         if use_alt_screen:
-            print("\033[?1049h\033[?25l", end="")
+            print("\033[?1049h\033[?25l", end="", flush=True)
         else:
-            print("\033[?25l", end="")
+            print("\033[?25l", end="", flush=True)
             if clear_screen:
                 os.system("cls" if os.name == "nt" else "clear")
         end_time = time.time() + duration if not persistent else None
@@ -114,11 +114,11 @@ def rain(
             termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
         time.sleep(0.5)
         if use_alt_screen:
-            print("\033[?25h\033[?1049l", end="")
+            print("\033[?25h\033[?1049l", end="", flush=True)
         elif clear_screen:
-            print("\033[0m\033[2J\033[H\033[?25h", end="")
+            print("\033[0m\033[2J\033[H\033[?25h", end="", flush=True)
         else:
-            print("\033[0m\033[?25h", end="")
+            print("\033[0m\033[?25h", end="", flush=True)
 
 
 def main():


### PR DESCRIPTION
## Summary
- Remove blank line after the thinking indicator so replies follow immediately.
- Align history replay and log output with the new formatting.
- Flush screensaver show/hide sequences so a single keypress dismisses it.

## Testing
- `python -m py_compile scripts/rain.py scripts/TerminalAI.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac22f3eef8833296bc1907bae9b940