### PR TITLE
Fix missing typing imports in TerminalAI script

### DIFF
--- a/scripts/TerminalAI.py
+++ b/scripts/TerminalAI.py
@@ -11,6 +11,7 @@ import re
 import threading
 import socket
 import subprocess
+from typing import Any, Dict, List, Optional
 from pathlib import Path
 from rain import rain
 from invoke_client import (


### PR DESCRIPTION
## Summary
- add the missing typing imports required by the TerminalAI script to use Dict, Any, List, and Optional

## Testing
- python -m compileall scripts/TerminalAI.py

------
https://chatgpt.com/codex/tasks/task_e_68db1aedc4308332ba38999e02ed0fa0